### PR TITLE
Support neo4j v3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ineo figure out this issue allowing to manage different Neo4j instances on diffe
 1. Execute the line bellow on your terminal:
 
    ```
-   curl -sSL http://getineo.cohesivestack.com | bash -s install
+   curl -sSL https://raw.githubusercontent.com/tandrewnichols/ineo/master/ineo | bash -s install
    ```
 
 2. Restart your terminal or execute the line bellow:

--- a/ineo
+++ b/ineo
@@ -22,11 +22,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-VERSION=1.0.0
+VERSION=1.1.0
 
 DEFAULT_HOME="$HOME/.ineo"
 
 DEFAULT_VERSION='2.3.1'
+LATEST_VERSION='3.2.3'
 
 DEFAULT_PORT='7474'
 
@@ -339,6 +340,9 @@ function create {
         ;;
       v)
         version=${OPTARG}
+        if [[ $version == "latest" ]]; then
+          version=${LATEST_VERSION}
+        fi
         ;;
       d)
         force_download=true
@@ -408,7 +412,7 @@ function create {
   mv ${TEMP_DIR}/${version}/neo4j-community-${version} ${INEO_HOME}/instances/${instance_name}
 
   # Set the port on the configuration file
-  https_port=${https_port:-$((${port} + 1))}
+  https_port=${https_port:-$((${port} - 1))}
   set_port $instance_name $port
   set_https_port $instance_name $https_port
   printf "\n  ${GREEN}The instance ${BOLD}${instance_name}${GREEN} was successfully created.${NF}\n\n"
@@ -657,49 +661,109 @@ function instances {
     local instance_name
     for instance_name in "${INSTANCES[@]}"; do
       version=$(head -n 1 $INEO_HOME/instances/$instance_name/.version)
-      port=$(sed -n '/^org\.neo4j\.server\.webserver\.port=\(.*\)$/s//\1/p' \
-        $INEO_HOME/instances/$instance_name/conf/neo4j-server.properties)
-      ssl=$(sed -n '/^org\.neo4j\.server\.webserver\.https.port=\(.*\)$/s//\1/p' \
-        $INEO_HOME/instances/$instance_name/conf/neo4j-server.properties)
+      port=$(get_port $instance_name)
+      ssl=$(get_https_port $instance_name)
+      bolt=$(get_bolt_port $instance_name)
 
       printf "\n  > instance '$instance_name'"
       printf "\n    VERSION: ${version}"
       printf "\n    PATH:    ${INEO_HOME}/instances/${instance_name}"
       printf "\n    PORT:    ${port}"
-      printf "\n    HTTPS:   ${ssl}\n"
+      printf "\n    HTTPS:   ${ssl}"
+      printf "\n    BOLT:    ${bolt}\n"
     done
     printf "\n"
   fi
 }
 
 # ==============================================================================
-# SET-PORT
+# GET/SET PORT
 # ==============================================================================
+
+function get_port {
+  local basedir=${INEO_HOME}/instances/${instance_name}/conf
+  if [ -e "${basedir}/neo4j-server.properties" ]; then
+    echo $(sed -n '/^org\.neo4j\.server\.webserver\.port=\(.*\)$/s//\1/p' \
+      $basedir/neo4j-server.properties)
+  else
+    echo $(sed -n '/^#\{0,1\}dbms\.connector\.http\.listen_address=:\(.*\)$/s//\1/p' \
+      ${basedir}/neo4j.conf)
+  fi
+}
 
 function set_port {
   local instance_name=$1
   local port=$2
-  sed -i.bak "/^\(org\.neo4j\.server\.webserver\.port=\).*/s//\1$port/" \
-    ${INEO_HOME}/instances/${instance_name}/conf/neo4j-server.properties
+  local basedir=${INEO_HOME}/instances/${instance_name}/conf
+  if [ -e "${basedir}/neo4j-server.properties" ]; then
+    sed -i.bak "/^\(org\.neo4j\.server\.webserver\.port=\).*/s//\1$port/" \
+      ${basedir}/neo4j-server.properties
+  else
+    sed -i.bak "/^#\{0,1\}\(dbms\.connector\.http\.listen_address=:\).*/s//\1$port/" \
+      ${basedir}/neo4j.conf
+  fi
+}
+
+function get_https_port {
+  local basedir=${INEO_HOME}/instances/${instance_name}/conf
+  if [ -e "${basedir}/neo4j-server.properties" ]; then
+    echo $(sed -n '/^org\.neo4j\.server\.webserver\.https\.port=\(.*\)$/s//\1/p' \
+      $basedir/neo4j-server.properties)
+  else
+    echo $(sed -n '/^#\{0,1\}dbms\.connector\.https\.listen_address=:\(.*\)$/s//\1/p' \
+      ${basedir}/neo4j.conf)
+  fi
 }
 
 function set_https_port {
   local instance_name=$1
   local port=$2
-  sed -i.bak "/^\(org\.neo4j\.server\.webserver\.https\.port=\).*/s//\1$port/" \
-    ${INEO_HOME}/instances/${instance_name}/conf/neo4j-server.properties
+  local basedir=${INEO_HOME}/instances/${instance_name}/conf/
+  if [ -e "${basedir}neo4j-server.properties" ]; then
+    sed -i.bak "/^\(org\.neo4j\.server\.webserver\.https\.port=\).*/s//\1$port/" \
+      ${basedir}/neo4j-server.properties
+  else
+    sed -i.bak "/^#\(dbms\.connector\.https\.listen_address=:\).*/s//\1$port/" \
+      ${basedir}/neo4j.conf
+  fi
+}
+
+function get_bolt_port {
+  local basedir=${INEO_HOME}/instances/${instance_name}/conf
+  if [ -e "${basedir}/neo4j-server.properties" ]; then
+    echo "Not supported by this version"
+  else
+    echo $(sed -n '/^#\{0,1\}dbms\.connector\.bolt\.listen_address=:\(.*\)$/s//\1/p' \
+      ${basedir}/neo4j.conf)
+  fi
+}
+
+function set_bolt_port {
+  local instance_name=$1
+  local port=$2
+  local basedir=${INEO_HOME}/instances/${instance_name}/conf
+  if [ -e "${basedir}/neo4j-server.properties" ]; then
+    echo "Not supported by this version"
+  else
+    sed -i.bak "/^#\(dbms\.connector\.bolt\.listen_address=:\).*/s//\1$port/" \
+      ${basedir}/neo4j.conf
+  fi
 }
 
 # Command
 function set-port {
   local https=false
+  local bolt=false
 
   shift
-  while getopts ":s" optname
+  while getopts ":s:b" optname
   do
     case "${optname}" in
       s)
         https=true
+        ;;
+      b)
+        bolt=true
         ;;
       *)
         invalid_command_param $OPTARG 'set-port'
@@ -741,21 +805,27 @@ function set-port {
     exit 1
   fi
 
+  local basedir=$INEO_HOME/instances/${instance_name}/conf
+
   # Check if the configuration file doesn't exists
-  if [ ! -f "$INEO_HOME/instances/${instance_name}/conf/neo4j-server.properties" ]; then
-    printf "\n  ${PURPLE}Error -> There is not an instance with the name ${BOLD}${instance_name}${PURPLE} or is not properly installed\n"
+  if [[ ! -f ${basedir}/neo4j-server.properties && ! -f ${basedir}/neo4j.conf ]]; then
+    printf "\n  ${PURPLE}Error -> There is not an instance with the name ${BOLD}${instance_name}${PURPLE} or it is not properly installed\n"
     printf "\n  ${NF}List installed instances typing:"
     printf "\n    ${CYAN}ineo instances${NF}\n\n"
+    exit 1
+  elif [[ ! -f ${basedir}/neo4j.conf && "$bolt" == true ]]; then
+    printf "\n  ${PURPLE}Error -> ${BOLD}${instance_name}${PURPLE} does not support the bolt protocol\n\n"
     exit 1
   fi
 
   if [[ "$https" == true ]]; then
-    set_port $instance_name $port
-
-    printf "\n  ${GREEN}The https port was successfully changed to ${BOLD}$port${GREEN}.${NF}\n\n"
-  else
     set_https_port $instance_name $port
-
+    printf "\n  ${GREEN}The https port was successfully changed to ${BOLD}$port${GREEN}.${NF}\n\n"
+  elif [[ "$bolt" == true ]]; then
+    set_bolt_port $instance_name $port
+    printf "\n  ${GREEN}The bolt port was successfully changed to ${BOLD}$port${GREEN}.${NF}\n\n"
+  else
+    set_port $instance_name $port
     printf "\n  ${GREEN}The http port was successfully changed to ${BOLD}$port${GREEN}.${NF}\n\n"
   fi
 
@@ -991,6 +1061,7 @@ HELP_SET_PORT="
 
   OPTIONS:
     -s    Use this option to change the SSL port
+    -b    Use this option to change the bolt port (neo4j version 3 only)
 
 "
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,49 @@
+{
+  "author": {
+    "name": "Carlos Forero"
+  },
+  "bin": {
+    "ineo": "./ineo"
+  },
+  "bugs": {
+    "url": "https://github.com/cohesivestack/ineo/issues"
+  },
+  "dependencies": {},
+  "description": "Neo4j instance manager and version manager",
+  "devDependencies": {},
+  "directories": {},
+  "homepage": "https://github.com/cohesivestack/ineo",
+  "keywords": [
+    "neo4",
+    "ineo",
+    "neo4j",
+    "version",
+    "manager",
+    "instance",
+    "test",
+    "testing"
+  ],
+  "license": "MIT",
+  "maintainers": [
+    {
+      "name": "cayasso",
+      "email": "cayasso@gmail.com"
+    }
+  ],
+  "name": "ineo",
+  "optionalDependencies": {},
+  "os": [
+    "!win32"
+  ],
+  "preferGlobal": true,
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/cohesivestack/ineo.git"
+  },
+  "script": {
+    "install": "./ineo install",
+    "uninstall": "./ineo uninstall"
+  },
+  "scripts": {},
+  "version": "1.1.0"
+}


### PR DESCRIPTION
I love this binary for simple neo4j instance management, since I use instances in multiple projects, but the lack of v3 support has become a problem. It's possible I'm missing things, but for generic use cases (installing, destroying, listing instances, changing ports) it works (tested locally with both neo4j v2.x and neo4j v3.x instances). Also added package.json as this _is_ on npm (pointing to this repo), but somehow this doesn't have a package.json. So I used the one already there and bumped the version.