### PR TITLE
Issue/44

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,19 +1,20 @@
 # Roadmap
 
-## Version 1.1
-
-* Output colors
-* Add webserver address during installation 
-* Make configuration compatible with Neo4j V3
-* V3 Add additional bolt port config
-* Add choice for Neo4j community or Neo4j enterprise edition
-
-## Versions 1.2
-
-* Command to backup and restore data
-* Option for automatic Ineo upgrades
-
 ## Version 1.3
 
 * Option to create new instance from existing instance
 * Command to execute a simple cypher statement against an instance
+
+## Version 1.2 - In development
+
+* Option to change configuration file
+* Command to backup and restore data
+* Option for automatic Ineo upgrades
+
+## Version 1.1 - Released on Jan 2018
+
+* Output colors
+* Add webserver address during installation
+* Make configuration compatible with Neo4j V3
+* V3 Add additional bolt port config
+* Add choice for Neo4j community or Neo4j enterprise edition

--- a/assert.sh
+++ b/assert.sh
@@ -111,7 +111,11 @@ assert() {
     result="$(sed -e :a -e '$!N;s/\n/\\n/;ta' <<< "$result")"
     [[ -z "$result" ]] && result="nothing" || result="\"$result\""
     [[ -z "$2" ]] && expected="nothing" || expected="\"$2\""
-    _assert_fail "expected $expected${_indent}got $result" "$1" "$3"
+
+    set +e
+    diff=$(diff -y <(echo -e "${expected}") <(echo -e "${result}"))
+    set -e
+    _assert_fail "expected ${expected}${_indent}got ${result}${_indent}diff \n${diff}" "$1" "$3"
 }
 
 assert_raises() {
@@ -134,7 +138,7 @@ _assert_fail() {
     report="test #$tests_ran \"$2${3:+ <<< $3}\" failed:${_indent}$1"
     if [[ -n "$STOP" ]]; then
         [[ -n "$DEBUG" ]] && echo
-        echo "$report"
+        echo -e "$report"
         exit 1
     fi
     tests_errors[$tests_failed]="$report"

--- a/ineo
+++ b/ineo
@@ -1616,7 +1616,6 @@ COMMAND=$1
 if [[ "$( uname )" == "Darwin" ]]; then
   # sed command is just incompatible with -i option
 	SED_CMD="sed -i ''"
-	exit
 fi
 
 set_instances

--- a/ineo
+++ b/ineo
@@ -26,7 +26,7 @@ VERSION=1.1.0
 
 DEFAULT_HOME="${HOME}/.ineo"
 
-DEFAULT_VERSION='3.3.1'
+DEFAULT_VERSION='3.4.5'
 
 DEFAULT_PORT='7474'
 
@@ -745,10 +745,14 @@ function autostart {
       exit 1
     fi
 	
+    # find out whose instance we are going to start
+    local owner=$(stat -c '%U' "${INEO_HOME}/instances/${instance_name}/bin/neo4j")
 
     printf "\n  start '${instance_name}'\n  "
 
-    "${INEO_HOME}/instances/${instance_name}/bin/neo4j" "start"
+    # because we are in autostart, we want to start the instances as if their owner would have started them,
+    # so they are able to stop and administrate them themselves
+    sudo -n -u "${owner}" -- "${INEO_HOME}/instances/${instance_name}/bin/neo4j" "start"
     
     # don't delay if this instance is the last to be autostarted
     if [[ "${instance_name}" != "${last}" ]]; then

--- a/ineo
+++ b/ineo
@@ -32,6 +32,8 @@ DEFAULT_PORT='7474'
 
 DEFAULT_EDITION='community'
 
+DEFAULT_AUTO_DELAY=3
+
 # NEO4J_HOSTNAME can be assigned from the environment, so can be changed
 # with testing to use tars in tars_for_test folder
 NEO4J_HOSTNAME="${NEO4J_HOSTNAME:-http://dist.neo4j.org}"
@@ -44,7 +46,7 @@ LOCK_DIR='/tmp/ineo.neo4j.instances.lock'
 
 TEMP_DIR="/tmp/$$.ineo"
 
-SED_CMD="sed -i''"
+SED_CMD="sed -i "
 
 # Regular Colors
 BLACK='\033[0;30m'
@@ -136,41 +138,43 @@ function configuration_exists {
 }
 
 # ==============================================================================
-# GET_VERSION
+# GET_INEO
 # ==============================================================================
 
-function get_version {
+# access ineo metadata information of an instance
+function get_ineo {
   local instance_name=$1
-  if [[ -f "${INEO_HOME}/instances/${instance_name}/.version" ]]; then
-    echo $(head -n 1 "${INEO_HOME}/instances/${instance_name}/.version")
+  local config_name=$2
+  
+  # prevent include to override global vars
+  local neo4j_version
+  local neo4j_edition
+  local ineo_start_auto
+  local ineo_start_order
+  local ineo_start_delay
+  
+  if [[ -f "${INEO_HOME}/instances/${instance_name}/.ineo" ]]; then
+    source "${INEO_HOME}/instances/${instance_name}/.ineo"
+    echo ${!config_name}
   else
     echo 'unknown'
   fi
 }
 
+# ==============================================================================
+# GET_VERSION
+# ==============================================================================
+
 function get_major_version {
   local instance_name=$1
-  local version=$(get_version "${instance_name}")
+  local version=$(get_ineo "${instance_name}" neo4j_version)
   echo "${version%%.*}"
 }
 
 function get_minor_version {
   local instance_name=$1
-  local version=$(get_version "${instance_name}")
+  local version=$(get_ineo "${instance_name}" neo4j_version)
   echo "${version%.*}"
-}
-
-# ==============================================================================
-# GET_EDITION
-# ==============================================================================
-
-function get_edition {
-  local instance_name=$1
-  if [[ -f "${INEO_HOME}/instances/${instance_name}/.edition" ]]; then
-    echo $(head -n 1 ${INEO_HOME}/instances/${instance_name}/.edition)
-  else
-    echo 'unknown'
-  fi
 }
 
 # ==============================================================================
@@ -197,6 +201,11 @@ function install {
   if [[ -n "${arg1}" ]]; then
     invalid_command_param "${arg1}" "install"
     exit 1
+  fi
+
+  # If user is root, we assume a "system" installation
+  if [[ "$(whoami)" == "root" ]]; then
+    DEFAULT_HOME=/var/lib/ineo
   fi
 
   # Set INEO_HOME variable
@@ -254,6 +263,29 @@ function install {
 
   # Move the TEMP_DIR to the target directory for ineo
   mv "${TEMP_DIR}" "${INEO_HOME}"
+
+  # Check if ineo service can be installed
+  if [[ $(whoami) == "root" ]]; then
+  	if [[ $(ps -o comm 1 | tail -n 1 ) == "systemd" ]]; then
+      cat >/lib/systemd/system/ineo.service <<EOF
+[Unit]
+Description=ineo - a Neo4j instance manager
+Documentation=https://github.com/cohesivestack/ineo
+After=network.target
+
+[Service]
+Type=oneshot
+Environment="INEO_HOME=/var/lib/ineo"
+ExecStart=/var/lib/ineo/bin/ineo autostart
+ExecStop=/var/lib/ineo/bin/ineo stop -q
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    fi
+  fi
+
 
   printf "\n  ${GREEN}Ineo was successfully installed in ${BOLD}${INEO_HOME}\n"
   printf "\n  ${NF}To start using the ${UNDERLINE}ineo${NF} command reopen your terminal or enter:"
@@ -512,11 +544,17 @@ function create {
     rm -rf "${INEO_HOME}/instances/${instance_name}"
   fi
 
-  # Create a hidden file with the version used in this installation
-  echo "${version}" > "${TEMP_DIR}/${version}/neo4j-${edition}-${version}/.version"
+  # Create a hidden file with meta information to this installation (e.g. version, edition, ...)
+  cat >"${TEMP_DIR}/${version}/neo4j-${edition}-${version}/.ineo" <<EOF
+# installation
+neo4j_version=${version}
+neo4j_edition=${edition}
 
-  # Create a hidden file with the edition used in this installation
-  echo "${edition}" > "${TEMP_DIR}/${version}/neo4j-${edition}-${version}/.edition"
+# autostart
+#ineo_start_auto=0
+#ineo_start_priority=
+#ineo_start_delay=${DEFAULT_AUTO_DELAY}
+EOF
 
   # Finnaly move the instance for installation
   mv ${TEMP_DIR}/${version}/neo4j-${edition}-${version} ${INEO_HOME}/instances/${instance_name}
@@ -620,7 +658,7 @@ function action {
 
     # If no instances then an error messages
     if [[ -z "${INSTANCES}" ]]; then
-      printf "\n  ${PURPLE}Error -> No instances created\n"
+      printf "\n  ${PURPLE}Error -> No instances created yet\n"
       printf "\n  ${NF}Try create an instance with the command:"
       printf "\n    ${CYAN}ineo create [your_instance_name]${NF}\n\n"
     fi
@@ -660,6 +698,70 @@ function action {
 
   done
   printf "\n"
+}
+
+# ==============================================================================
+# AUTOSTART
+# ==============================================================================
+
+function autostart {
+  # If no instances then an error messages
+  if [[ -z "${INSTANCES}" ]]; then
+    printf "\n  ${PURPLE}Error -> No instances created yet\n"
+    printf "\n  ${NF}Try create an instance with the command:"
+    printf "\n    ${CYAN}ineo create [your_instance_name]${NF}\n\n"
+    exit 1
+  fi
+
+  # Pick all instances with ineo_start_auto = 1
+  local instance_name
+  local instance_list
+  local start_auto
+  local start_priority
+  for instance_name in "${INSTANCES[@]}"; do
+    start_auto=$(get_ineo "${instance_name}" "ineo_start_auto")
+    if [[ "${start_auto}" == 1 ]]; then
+      start_priority=$(get_ineo "${instance_name}" "ineo_start_priority")
+      if [[ -z "${start_priority}" ]]; then
+        start_priority=0
+      fi
+      instance_list+="${start_priority}	${instance_name}\n"
+    fi
+  done
+
+  # Order instances by priority
+  local instances=()
+  for instance_name in "$(echo -e $instance_list | sort -rn)"; do
+    instances+=($(echo "${instance_name}" | cut -f2 -d' '))
+  done
+
+  local start_delay
+  local last=${instances[@]: -1:1}
+  for instance_name in "${instances[@]}"; do
+    if [[ ! -f "${INEO_HOME}/instances/${instance_name}/bin/neo4j" ]]; then
+      printf "\n  ${PURPLE}Error -> The instance ${BOLD}${instance_name}${PURPLE} seems that is not properly installed\n"
+      printf "\n  ${NF}You can recreate the instance with the command:"
+      printf "\n    ${CYAN}ineo create -f ${instance_name}${NF}\n\n"
+      exit 1
+    fi
+	
+
+    printf "\n  start '${instance_name}'\n  "
+
+    "${INEO_HOME}/instances/${instance_name}/bin/neo4j" "start"
+    
+    # don't delay if this instance is the last to be autostarted
+    if [[ "${instance_name}" != "${last}" ]]; then
+      # delay start of next instance depending on delay setting
+      # this can prevents server load peaks
+      start_delay=$(get_ineo "${instance_name}" "ineo_start_delay")
+      if [[ -z "${start_delay}" ]]; then
+        start_delay=${DEFAULT_AUTO_DELAY}
+      fi
+      printf "  delay next start by '${start_delay}' secs\n  "
+      sleep "${start_delay}"
+    fi
+  done
 }
 
 # ==============================================================================
@@ -852,8 +954,8 @@ function instances {
         ssl="(default)"
       fi
 
-      local version=$(get_version "${instance_name}")
-      local edition=$(get_edition "${instance_name}")
+      local version=$(get_ineo "${instance_name}" neo4j_version)
+      local edition=$(get_ineo "${instance_name}" neo4j_edition)
 
       printf "\n  > instance '${instance_name}'"
       printf "\n    VERSION: ${version}"
@@ -1514,6 +1616,7 @@ COMMAND=$1
 if [[ "$( uname )" == "Darwin" ]]; then
   # sed command is just incompatible with -i option
 	SED_CMD="sed -i ''"
+	exit
 fi
 
 set_instances
@@ -1552,8 +1655,11 @@ case "${COMMAND}" in
   destroy)
     destroy $@
     ;;
-  console|start|start-no-wait|stop|restart|status|info)
+  console|start|stop|restart|status|info)
     action $@
+    ;;
+  autostart)
+    autostart $@
     ;;
   delete-db)
     delete-db $@

--- a/ineo
+++ b/ineo
@@ -369,6 +369,13 @@ function uninstall {
     fi
   fi
 
+  # Check if ineo service has been installed
+  if [[ $(whoami) == "root" ]]; then
+    if [[ $(ps -o comm 1 | tail -n 1 ) == "systemd" ]]; then
+      rm /lib/systemd/system/ineo.service
+    fi
+  fi
+
   # Remove directory
   rm -r "${INEO_HOME}"
 
@@ -1564,13 +1571,14 @@ HELP_INSTALL="
     Install ineo
 
     Don't use this command if you already have ineo installed and working
-    correctly.
+    correctly. If root user installs ineo on a systemd OS, a systemd
+    service will also be install to support autostart on instances.
 
   OPTIONS:
     -d <directory_name>  Directory name (absolute path) where ineo will be
                          installed
 
-                         Default: ~/.ineo
+                         Default: ~/.ineo or /var/lib/ineo if root user
 
 "
 

--- a/ineo
+++ b/ineo
@@ -47,7 +47,7 @@ LOCK_DIR='/tmp/ineo.neo4j.instances.lock'
 TEMP_DIR="/tmp/$$.ineo"
 
 SED_CMD="sed -i "
-OWNER_CMD="stat -c '%U'"
+OWNER_CMD="stat -c %U"
 
 # Regular Colors
 BLACK='\033[0;30m'

--- a/ineo
+++ b/ineo
@@ -47,6 +47,7 @@ LOCK_DIR='/tmp/ineo.neo4j.instances.lock'
 TEMP_DIR="/tmp/$$.ineo"
 
 SED_CMD="sed -i "
+OWNER_CMD="stat -c '%U'"
 
 # Regular Colors
 BLACK='\033[0;30m'
@@ -749,13 +750,13 @@ function autostart {
     fi
 	
     # find out whose instance we are going to start
-    local owner=$(stat -c '%U' "${INEO_HOME}/instances/${instance_name}/bin/neo4j")
+    local owner=$(${OWNER_CMD} "${INEO_HOME}/instances/${instance_name}/bin/neo4j")
 
     printf "\n  start '${instance_name}'\n  "
 
     # because we are in autostart, we want to start the instances as if their owner would have started them,
     # so they are able to stop and administrate them themselves
-    sudo -n -u "${owner}" -- "${INEO_HOME}/instances/${instance_name}/bin/neo4j" "start"
+    sudo -n -u ${owner} -- "${INEO_HOME}/instances/${instance_name}/bin/neo4j" "start"
     
     # don't delay if this instance is the last to be autostarted
     if [[ "${instance_name}" != "${last}" ]]; then
@@ -1623,6 +1624,7 @@ COMMAND=$1
 if [[ "$( uname )" == "Darwin" ]]; then
   # sed command is just incompatible with -i option
 	SED_CMD="sed -i ''"
+	OWNER_CMD="stat -f %Su"
 fi
 
 set_instances

--- a/ineo
+++ b/ineo
@@ -272,14 +272,16 @@ function install {
 [Unit]
 Description=ineo - a Neo4j instance manager
 Documentation=https://github.com/cohesivestack/ineo
-After=network.target
+After=network.target remote-fs.target
 
 [Service]
 Type=oneshot
+SyslogIdentifier=ineo
 Environment="INEO_HOME=/var/lib/ineo"
 ExecStart=/var/lib/ineo/bin/ineo autostart
 ExecStop=/var/lib/ineo/bin/ineo stop -q
 RemainAfterExit=yes
+LimitNOFILE=20000
 
 [Install]
 WantedBy=multi-user.target

--- a/ineo
+++ b/ineo
@@ -183,13 +183,17 @@ function get_minor_version {
 # ==============================================================================
 
 function install {
+  local as_service=false
 
   shift
-  while getopts ":d:" optname
+  while getopts ":d:S" optname
   do
     case "${optname}" in
       d)
         INEO_HOME=${OPTARG}
+        ;;
+      S)
+        as_service=true
         ;;
       *)
         invalid_command_param "${OPTARG}" "install"
@@ -204,8 +208,19 @@ function install {
     exit 1
   fi
 
-  # If user is root, we assume a "system" installation
-  if [[ "$(whoami)" == "root" ]]; then
+  # If installation as service requested we need to be root and be on a systemd OS
+  if [[ "${as_service}" == true ]]; then
+    # Check if we are root
+    if [[ "$(whoami)" != "root" ]]; then
+      printf "\n  ${PURPLE}Error -> Installation as a service can only be done by root user${NF}\n\n"
+      exit 1
+    fi
+
+    if [[ $(ps -o comm 1 | tail -n 1 ) != "systemd" ]]; then
+      printf "\n  ${PURPLE}Error -> Installation as a service can only be done on a systemd enabled OS${NF}\n\n"
+      exit 1
+    fi
+
     DEFAULT_HOME=/var/lib/ineo
   fi
 
@@ -266,9 +281,8 @@ function install {
   mv "${TEMP_DIR}" "${INEO_HOME}"
 
   # Check if ineo service can be installed
-  if [[ $(whoami) == "root" ]]; then
-  	if [[ $(ps -o comm 1 | tail -n 1 ) == "systemd" ]]; then
-      cat >/lib/systemd/system/ineo.service <<EOF
+  if [[ "${as_service}" == true ]]; then
+    cat >/lib/systemd/system/ineo.service <<EOF
 [Unit]
 Description=ineo - a Neo4j instance manager
 Documentation=https://github.com/cohesivestack/ineo
@@ -287,9 +301,8 @@ LimitNOFILE=20000
 WantedBy=multi-user.target
 EOF
 
-      # enable service so instances get autostarted if marked as such
-      systemctl enable ineo
-    fi
+    # enable service so instances get autostarted if marked as such
+    systemctl enable ineo
   fi
 
 
@@ -1578,7 +1591,9 @@ HELP_INSTALL="
     -d <directory_name>  Directory name (absolute path) where ineo will be
                          installed
 
-                         Default: ~/.ineo or /var/lib/ineo if root user
+                         Default: ~/.ineo or /var/lib/ineo if using -S
+
+    -S                   Install ineo as a service (only on systemd OSes)
 
 "
 

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ NEO4J_HOSTNAME='http://dist.neo4j.org'
 DEFAULT_VERSION='all'
 DEFAULT_EDITION='all'
 DEFAULT_AUTO_DELAY=3
-LAST_VERSION='3.3.1'
+LAST_VERSION='3.4.5'
 SED_CMD="sed -i "
 
 # Regular Colors
@@ -95,10 +95,10 @@ if [ ${versions[0]} == 'all' ]; then
   # check current java version and select "all" version appropriately
   java_version=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2)
   if [[ "${java_version%*.*}" < "1.8" ]]; then
-    versions=(1.9.9 2.3.6 3.0.3 3.3.1)
+    versions=(1.9.9 2.3.6 3.0.3 3.4.5)
   else
     # neo4j 1.9.x is not compatible with java >= 1.8
-    versions=(2.3.6 3.0.3 3.3.1)
+    versions=(2.3.6 3.0.3 3.4.5)
   fi
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,9 @@
 NEO4J_HOSTNAME='http://dist.neo4j.org'
 DEFAULT_VERSION='all'
 DEFAULT_EDITION='all'
+DEFAULT_AUTO_DELAY=3
 LAST_VERSION='3.3.1'
+SED_CMD="sed -i "
 
 # Regular Colors
 BLACK='\033[0;30m'
@@ -26,6 +28,12 @@ NF='\033[0m'
 # ==============================================================================
 # PROVISION
 # ==============================================================================
+
+# make OS specific changed
+if [[ "$( uname )" == "Darwin" ]]; then
+  # sed command is just incompatible with -i option
+	SED_CMD="sed -i ''"
+fi
 
 versions=()
 editions=()
@@ -634,7 +642,7 @@ CreateWithIncorrectEdition() {
 
   local i
   for ((i=0; i<${#params[*]}; i+=1)); do
-    setup "${FUNCNAME[0]}"
+    setup "${FUNCNAME[0]} ${params[i]}"
 
     # Make an installation
     assert_raises "./ineo install -d $(pwd)/ineo_for_test" 0
@@ -897,6 +905,7 @@ CreateAnInstanceOnAExistingDirectoryAndTryAgainWithFOption() {
 }
 tests+=('CreateAnInstanceOnAExistingDirectoryAndTryAgainWithFOption')
 
+
 # ==============================================================================
 # TEST INSTANCE ACTIONS (START, STATUS, RESTART, STOP)
 # ==============================================================================
@@ -1124,6 +1133,183 @@ $(get_not_running_message $version twitter $pid_twitter)"
   assert_end ExecuteActionsOnVariousInstancesCorrectly
 }
 tests+=('ExecuteActionsOnVariousInstancesCorrectly')
+
+
+# ==============================================================================
+# TEST AUTOSTART
+# ==============================================================================
+
+AutostartWithoutAnyInstance() {
+  setup "${FUNCNAME[0]}"
+
+  # Make an installation
+  assert_raises "./ineo install -d $(pwd)/ineo_for_test" 0
+
+  local action
+  for action in "${actions[@]}"; do
+    assert_raises "./ineo autostart" 1
+    assert        "./ineo autostart" \
+"
+  ${PURPLE}Error -> No instances created yet
+
+  ${NF}Try create an instance with the command:
+    ${CYAN}ineo create [your_instance_name]${NF}"
+  done
+
+  assert_end AutostartWithoutAnyInstance
+}
+tests+=('AutostartWithoutAnyInstance')
+
+
+AutostartSomeInstances() {
+  setup "${FUNCNAME[0]}"
+
+  # Make an installation
+  assert_raises "./ineo install -d $(pwd)/ineo_for_test" 0
+
+  assert_raises "./ineo create -p 7474 twitter" 0
+  assert_raises "./ineo create -p 8484 facebook" 0
+  assert_raises "./ineo create -p 9494 apple" 0
+
+  ${SED_CMD} -E "/^.*ineo_start_auto=.*$/ s/.*/ineo_start_auto=1/g" \
+    ${INEO_HOME}/instances/apple/.ineo
+  ${SED_CMD} -E "/^.*ineo_start_auto=.*$/ s/.*/ineo_start_auto=1/g" \
+    ${INEO_HOME}/instances/twitter/.ineo
+
+  assert_raises "./ineo autostart" 0
+
+  set_instance_pid twitter
+  local pid_twitter=$pid
+  assert_run_pid $pid_twitter
+
+  # should not have started at all, so no PID file yet
+  assert_raises \
+    "test -f $INEO_HOME/instances/facebook/run/neo4j.pid" 1
+
+  set_instance_pid apple
+  local pid_apple=$pid
+  assert_run_pid $pid_apple
+
+  assert_raises "./ineo stop -q" 0
+
+  assert_end AutostartSomeInstances
+}
+tests+=('AutostartSomeInstances')
+
+
+AutostartWithDelay() {
+  setup "${FUNCNAME[0]}"
+
+  # Make an installation
+  assert_raises "./ineo install -d $(pwd)/ineo_for_test" 0
+
+  assert_raises "./ineo create -p 7474 twitter" 0
+  assert_raises "./ineo create -p 8484 facebook" 0
+
+  ${SED_CMD} -E "/^.*ineo_start_auto=.*$/ s/.*/ineo_start_auto=1/g" \
+    ${INEO_HOME}/instances/facebook/.ineo
+  ${SED_CMD} -E "/^.*ineo_start_auto=.*$/ s/.*/ineo_start_auto=1/g" \
+    ${INEO_HOME}/instances/twitter/.ineo
+
+  local time=$(date +"%s")
+  assert_raises "./ineo autostart" 0
+  time=$(($(date +"%s")-${time}))
+
+  assert_raises "[ ${time} -ge ${DEFAULT_AUTO_DELAY} ]" 0
+
+  set_instance_pid twitter
+  local pid_twitter=$pid
+  assert_run_pid $pid_twitter
+
+  set_instance_pid facebook
+  local pid_facebook=$pid
+  assert_run_pid $pid_facebook
+
+  assert_raises "./ineo stop -q" 0
+
+
+  ${SED_CMD} -E "/^.*ineo_start_delay=.*$/ s/.*/ineo_start_delay=0/g" \
+    ${INEO_HOME}/instances/facebook/.ineo
+  ${SED_CMD} -E "/^.*ineo_start_delay=.*$/ s/.*/ineo_start_delay=0/g" \
+    ${INEO_HOME}/instances/twitter/.ineo
+
+  time=$(date +"%s")
+  assert_raises "./ineo autostart" 0
+  time=$(($(date +"%s")-${time}))
+
+  assert_raises "[ ${time} -lt ${DEFAULT_AUTO_DELAY} ]" 0
+
+  set_instance_pid twitter
+  pid_twitter=$pid
+  assert_run_pid $pid_twitter
+
+  set_instance_pid facebook
+  pid_facebook=$pid
+  assert_run_pid $pid_facebook
+
+  assert_raises "./ineo stop -q" 0
+
+  assert_end AutostartWithDelay
+}
+tests+=('AutostartWithDelay')
+
+
+AutostartWithPriority() {
+  setup "${FUNCNAME[0]}"
+
+  # Make an installation
+  assert_raises "./ineo install -d $(pwd)/ineo_for_test" 0
+
+  # testing starting order is not really easy to do, because the autostart
+  # is not running in a separate thread/process and cannot be "watched".
+  # so the "trick" is to use the same port and see which neo4j is able
+  # to start. the first one will win.
+  assert_raises "./ineo create -p 7474 twitter" 0
+  assert_raises "./ineo create -p 7474 facebook" 0
+
+  ${SED_CMD} -E "/^.*ineo_start_auto=.*$/ s/.*/ineo_start_auto=1/g" \
+    ${INEO_HOME}/instances/facebook/.ineo
+  ${SED_CMD} -E "/^.*ineo_start_auto=.*$/ s/.*/ineo_start_auto=1/g" \
+    ${INEO_HOME}/instances/twitter/.ineo
+
+  ${SED_CMD} -E "/^.*ineo_start_priority=.*$/ s/.*/ineo_start_priority=10/g" \
+    ${INEO_HOME}/instances/facebook/.ineo
+  ${SED_CMD} -E "/^.*ineo_start_priority=.*$/ s/.*/ineo_start_priority=100/g" \
+    ${INEO_HOME}/instances/twitter/.ineo
+
+  assert_raises "./ineo autostart" 0
+
+  set_instance_pid twitter
+  local pid_twitter=$pid
+  assert_run_pid $pid_twitter
+
+  set_instance_pid facebook
+  pid_facebook=$pid
+  assert_not_run_pid $pid_facebook
+
+  assert_raises "./ineo stop -q" 0
+
+
+  ${SED_CMD} -E "/^.*ineo_start_priority=.*$/ s/.*/ineo_start_priority=100/g" \
+    ${INEO_HOME}/instances/facebook/.ineo
+  ${SED_CMD} -E "/^.*ineo_start_priority=.*$/ s/.*/ineo_start_priority=1/g" \
+    ${INEO_HOME}/instances/twitter/.ineo
+
+  assert_raises "./ineo autostart" 0
+
+  set_instance_pid facebook
+  pid_facebook=$pid
+  assert_run_pid $pid_facebook
+
+  set_instance_pid twitter
+  pid_twitter=$pid
+  assert_not_run_pid $pid_twitter
+
+  assert_raises "./ineo stop -q" 0
+
+  assert_end AutostartWithPriority
+}
+tests+=('AutostartWithPriority')
 
 
 # ==============================================================================

--- a/test.sh
+++ b/test.sh
@@ -148,8 +148,8 @@ set -e
 # Set the variables to create instances
 # ------------------------------------------------------------------------------
 
-export NEO4J_HOSTNAME="file:///$(pwd)/fake_neo4j_host"
-export INEO_HOSTNAME="file:///$(pwd)/fake_ineo_host"
+export NEO4J_HOSTNAME="file://$(pwd)/fake_neo4j_host"
+export INEO_HOSTNAME="file://$(pwd)/fake_ineo_host"
 export INEO_HOME="$(pwd)/ineo_for_test"
 
 # ==============================================================================
@@ -821,7 +821,7 @@ CreateAnInstanceWithABadTarAndTryAgainWithDOption() {
   $command_truncate -s20MB bad_tar_for_test/neo4j-community-${LAST_VERSION}-unix.tar.gz
 
   # Change the NEO4J_HOSTNAME for test to download the bad tar
-  export NEO4J_HOSTNAME="file:///$(pwd)/bad_tar_for_test"
+  export NEO4J_HOSTNAME="file://$(pwd)/bad_tar_for_test"
 
   # Make an installation
   assert_raises "./ineo install -d $(pwd)/ineo_for_test" 0
@@ -861,7 +861,7 @@ CreateAnInstanceWithABadTarAndTryAgainWithDOption() {
   assert_raises "test -f $(pwd)/ineo_for_test/instances/twitter/bin/neo4j" 0
 
   # Restore the correct NEO4J_HOSTNAME for test
-  export NEO4J_HOSTNAME="file:///$(pwd)/fake_neo4j_host"
+  export NEO4J_HOSTNAME="file://$(pwd)/fake_neo4j_host"
 
   assert_end CreateAnInstanceWithABadTarAndTryAgainWithDOption
 }


### PR DESCRIPTION
added a "system" installation if run by root on a linux system. it adds a systemd service to start and stop ineo autostart instances. at a later stage, this could be done on macs as well, of course. i don't have experience writing those, so i have not added it.

where possible there is a test for it. couldn't really add a systemd service test, because of the requirements.

i have added a diff to failed tests. maybe that is helpful.