### PR TITLE
Adding auto-completion to ineo.

### DIFF
--- a/ineo
+++ b/ineo
@@ -65,6 +65,20 @@ BOLD='\033[1m'
 NF='\033[0m'
 
 # ==============================================================================
+# BASH AUTO COMPLETION
+# ==============================================================================
+
+function ineo_autocompletion { 
+    if [ "${#COMP_WORDS[@]}" -eq "2" ]; then
+        COMPREPLY=($(compgen -W "create set-port versions instances start stop restart status shell console delete-db 
+        destroy install update uninstall help" "${COMP_WORDS[1]}"))
+    else
+        COMPREPLY=$(compgen -W "$(ineo instances|egrep '> instance'|sed "s/> instance '\(.*\)'/ \1/g"|sed "s/\s*//g")" 
+        "${COMP_WORDS[-1]}")
+    fi
+}
+
+# ==============================================================================
 # SET INSTANCES FUNCTION
 # ==============================================================================
 
@@ -251,6 +265,11 @@ function install {
     # Add the line in .bashrc to export the variable
     echo "${line_for_bashrc}" >> ~/.bashrc
   fi
+  
+  # Export the auto completion setting line to activate autocompletion
+  if ! grep -Fq "complete -F ineo_autocompletion ineo" ~/.bashrc; then
+    echo "complete -F ineo_autocompletion ineo" >> ~/.bashrc
+  fi  
 
   # Move the TEMP_DIR to the target directory for ineo
   mv "${TEMP_DIR}" "${INEO_HOME}"


### PR DESCRIPTION
Thank you very much for ineo.

I often find myself wondering what the name of a specific instance I have created is exactly and so I went ahead and added auto-complete.

This is a first proposal where:

* If the user simply types `ineo` followed by double `tab`, then they get suggestions for all the commands supported by ineo. 
    * *This is not dynamic* and if a new command was to be added to `ineo`, then this would have to be reflected in the suggestions as well.

* If the user types `ineo` followed by a partial command and `tab`, then they get auto-completion for that specific command.
    * For example: `ineo se` followed by `<tab>` will auto-complete to `ineo set-port`

* If the user has already typed `ineo <command> [options]` followed by `tab`, then `ineo` will auto-complete the name of an existing instance.
    * This step **is dynamic**. So, every time you hit `<tab>` under these conditions, bash runs an `ineo instances` command in the background to retrieve the names of the installed instances and then runs `complete` on those names to suggest the auto-completion.

* *Please note:*, to activate the auto-complete feature, the line `complete -F ineo_autocompletion ineo` would have to be added to the `~/.bashrc`. I have added this myself but to date have not tested it.

If required, I could go ahead and add auto-completion taking into account the structure of each command (?). 

However, this would mean that every time some `ineo` command changes, the auto-completion part would have to be checked as well to make sure that it complies, which might mean an additional headache for maintenance. As far as my use-case is concerned however, simply having auto-complete on the instance names is convenient enough. (Obviously, this would have to be mentioned in the documentation, once finalised).

All the best
