### PR TITLE
Fix backup for Neo4j>=4.0.0 based instances.

### DIFF
--- a/ineo
+++ b/ineo
@@ -1637,13 +1637,13 @@ function backup {
     ${INEO_HOME}/instances/${instance_name}/bin/neo4j stop
   fi
   
-  backup_database="graph.db"
+  database_to_work_on="graph.db"
   # If Neo4j >=4.0.0 dump the default neo4j database
   if [[ $(get_major_version "${instance_name}") -ge "4" ]]; then
-    backup_database="neo4j"
+    database_to_work_on="neo4j"
   fi
 
-  "${INEO_HOME}/instances/${instance_name}/bin/neo4j-admin" dump --database="${backup_database}" --to="${path}"
+  "${INEO_HOME}/instances/${instance_name}/bin/neo4j-admin" dump --database="${database_to_work_on}" --to="${path}"
 
   local success=$?
   if [[ "${success}" -ne 0 ]]; then
@@ -1742,8 +1742,14 @@ function restore {
     # Stop the instance
     ${INEO_HOME}/instances/${instance_name}/bin/neo4j stop
   fi
+  
+  database_to_work_on="graph.db"
+  # If Neo4j >=4.0.0 dump the default neo4j database
+  if [[ $(get_major_version "${instance_name}") -ge "4" ]]; then
+    database_to_work_on="neo4j"
+  fi
 
-  "${INEO_HOME}/instances/${instance_name}/bin/neo4j-admin" load --from="${file}" --database="graph.db" --force
+  "${INEO_HOME}/instances/${instance_name}/bin/neo4j-admin" load --from="${file}" --database="${database_to_work_on}" --force
 
   local success=$?
   if [[ "${success}" -ne 0 ]]; then

--- a/ineo
+++ b/ineo
@@ -45,7 +45,7 @@ NEO4J_HOSTNAME="${NEO4J_HOSTNAME:-http://dist.neo4j.org}"
 
 # INEO_HOSTNAME can be assigned from the environment, so it can be changed
 # with testing to use a mock
-INEO_HOSTNAME="${INEO_HOSTNAME:-https://raw.githubusercontent.com/cohesivestack/ineo/master}"
+INEO_HOSTNAME="${INEO_HOSTNAME:-http://ineo.cohesivestack.com}"
 
 LOCK_DIR='/tmp/ineo.neo4j.instances.lock'
 

--- a/ineo
+++ b/ineo
@@ -1636,8 +1636,14 @@ function backup {
     # Stop the instance
     ${INEO_HOME}/instances/${instance_name}/bin/neo4j stop
   fi
+  
+  backup_database="graph.db"
+  # If Neo4j >=4.0.0 dump the default neo4j database
+  if [[ $(get_major_version "${instance_name}") -ge "4" ]]; then
+    backup_database="neo4j"
+  fi
 
-  "${INEO_HOME}/instances/${instance_name}/bin/neo4j-admin" dump --database="graph.db" --to="${path}"
+  "${INEO_HOME}/instances/${instance_name}/bin/neo4j-admin" dump --database="${backup_database}" --to="${path}"
 
   local success=$?
   if [[ "${success}" -ne 0 ]]; then

--- a/ineo
+++ b/ineo
@@ -45,7 +45,7 @@ NEO4J_HOSTNAME="${NEO4J_HOSTNAME:-http://dist.neo4j.org}"
 
 # INEO_HOSTNAME can be assigned from the environment, so it can be changed
 # with testing to use a mock
-INEO_HOSTNAME="${INEO_HOSTNAME:-http://ineo.cohesivestack.com}"
+INEO_HOSTNAME="${INEO_HOSTNAME:-https://raw.githubusercontent.com/cohesivestack/ineo/master}"
 
 LOCK_DIR='/tmp/ineo.neo4j.instances.lock'
 


### PR DESCRIPTION
Using the latest `ineo` and on a Neo4j 4.4.0 instance, running `ineo backup` fails with *"Database does not exist: graph.db"*.

This is because `ineo` is [trying to "dump" `graph.db` specifically](https://github.com/cohesivestack/ineo/blob/master/ineo#L1640), which would not be there for Neo4j versions 4.0.0 and later.

For versions 4.0.0 and later, Neo4j seems to now be doing partly what ineo was built to do. If you run a `show databases`, you get: 
![image](https://user-images.githubusercontent.com/1336337/146202679-a1b459bc-6130-48d8-84ca-3a2aef2c6bee.png)

And if you `~/.ineo/instances/some_instance/bin/neo4j-admin store-info --all ../data/databases`, you can get the same information.

The quick fix for this (what this PR is doing) is to detect that the instance version is 4 or older and if that is the case, change the database name to the default (since also, the default configuration for a given `ineo` instance is `dbms.default_database=neo4j`).

Ideally, it would also be nice to have the backup work over a particular database (So,*" backup database X from instance Y to file Z"* and *"restore database A from file B on instance C"*.

Also please keep in mind that [backup and restore might *appear* to not be working (but it will).](https://neo4j.com/developer/kb/neo4j-admin-load-causes-not-a-valid-neo4j-archive/)