### PR TITLE
Fix default url

### DIFF
--- a/ineo
+++ b/ineo
@@ -45,7 +45,7 @@ NEO4J_HOSTNAME="${NEO4J_HOSTNAME:-http://dist.neo4j.org}"
 
 # INEO_HOSTNAME can be assigned from the environment, so it can be changed
 # with testing to use a mock
-INEO_HOSTNAME="${INEO_HOSTNAME:-https://raw.githubusercontent.com/cohesivestack/ineo/master}"
+INEO_HOSTNAME="${INEO_HOSTNAME:-http://ineo.cohesivestack.com}"
 
 LOCK_DIR='/tmp/ineo.neo4j.instances.lock'
 

--- a/ineo
+++ b/ineo
@@ -45,7 +45,7 @@ NEO4J_HOSTNAME="${NEO4J_HOSTNAME:-http://dist.neo4j.org}"
 
 # INEO_HOSTNAME can be assigned from the environment, so it can be changed
 # with testing to use a mock
-INEO_HOSTNAME="${INEO_HOSTNAME:-http://ineo.cohesivestack.com}"
+INEO_HOSTNAME="${INEO_HOSTNAME:-https://raw.githubusercontent.com/cohesivestack/ineo/master}"
 
 LOCK_DIR='/tmp/ineo.neo4j.instances.lock'
 


### PR DESCRIPTION
The latest version of `ineo` actually **fails** to install via the method indicated in the `readme.md`:

```
    curl -sSL https://raw.githubusercontent.com/cohesivestack/ineo/v2.1.0/ineo | bash -s install
```

If you examine `~/.ineo/bin/ineo` you will find that its file size is 0 (at least in my case on Ubuntu 21.04 it was). 

The "problem" is ofcourse [on line 362](https://github.com/cohesivestack/ineo/blob/master/ineo#L362) because the installation in this case (where the script is downloaded and sent to bash) is not started by `ineo` and is "re-downloaded" from the hostname (which is set [on line 48](https://github.com/cohesivestack/ineo/blob/master/ineo#L48), which now is not pointing to the correct URL, which fails silently, which results in an `ineo` with 0 file size :/ ).

This PR corrects that so that the latest version available on github is picked up.

This might not be what you are after though (because the last version on github might be the last "development" version) and it might be worth the "trouble" to set up github releases (which makes it even easier to pick up whatever file the latest release would point to).

This addresses issues:
#56 #57 #58 

Hope this helps.
